### PR TITLE
Added in imagemagick to configure php imagick supported file types

### DIFF
--- a/Dockerfile-5.6
+++ b/Dockerfile-5.6
@@ -219,6 +219,9 @@ RUN apk add --no-cache php5-mcrypt \
 
 # Missing: php5-imagick, php5-redis
 
+# Imagick support file types
+RUN apk add --no-cache imagemagick
+
 # Imagick
 RUN apk --no-cache add ca-certificates wget && \
   apk add --no-cache imagemagick-dev && \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -224,6 +224,9 @@ RUN apk add --no-cache \
   php7-intl@php \ 
   php7-fpm@php
 
+# Imagick support file types
+RUN apk add --no-cache imagemagick
+
 # These only exist in 7.1, not 7.2
 RUN apk add --no-cache php7-mcrypt@php \
   php7-xmlrpc@php

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -224,6 +224,9 @@ RUN apk add --no-cache \
   php7-intl@php \ 
   php7-fpm@php
 
+# Imagick support file types
+RUN apk add --no-cache imagemagick
+
 RUN mkdir -p /src && \
   ln -s /etc/php7 /etc/php && \
   ln -s /usr/bin/php7 /usr/bin/php && \


### PR DESCRIPTION
Currently in all php version the php -i shows Imagick as: 
ImageMagick number of supported formats:  => 0

Adding in imagemagick through apk all these now have the full file support list of: 
ImageMagick number of supported formats:  => 220
ImageMagick supported formats => 3FR, 3G2, 3GP, AAI, AI, ART, ARW, AVI, AVS, BGR, BGRA, BGRO, BMP, BMP2, BMP3, BRF, CAL, CALS, CANVAS, CAPTION, CIN, CIP, CLIP, CMYK, CMYKA, CR2, CRW, CUR, CUT, DCM, DCR, DCX, DDS, DFONT, DNG, DOT, DPX, DXT1, DXT5, EPDF, EPI, EPS, EPS2, EPS3, EPSF, EPSI, EPT, EPT2, EPT3, ERF, FAX, FILE, FITS, FRACTAL, FTP, FTS, G3, G4, GIF, GIF87, GRADIENT, GRAY, GROUP4, GV, HALD, HDR, HISTOGRAM, HRZ, HTM, HTML, HTTP, HTTPS, ICB, ICO, ICON, IIQ, INFO, INLINE, IPL, ISOBRL, ISOBRL6, JNG, JNX, JPE, JPEG, JPG, JPS, JSON, K25, KDC, LABEL, M2V, M4V, MAC, MAP, MASK, MAT, MATTE, MEF, MIFF, MKV, MNG, MONO, MOV, MP4, MPC, MPEG, MPG, MRW, MSL, MSVG, MTV, MVG, NEF, NRW, NULL, ORF, OTB, OTF, PAL, PALM, PAM, PANGO, PATTERN, PBM, PCD, PCDS, PCL, PCT, PCX, PDB, PDF, PDFA, PEF, PES, PFA, PFB, PFM, PGM, PICON, PICT, PIX, PJPEG, PLASMA, PNG, PNG00, PNG24, PNG32, PNG48, PNG64, PNG8, PNM, PPM, PS, PS2, PS3, PSB, PSD, PTIF, PWP, RADIAL-GRADIENT, RAF, RAS, RAW, RGB, RGBA, RGBO, RGF, RLA, RLE, RMF, RW2, SCR, SCT, SFW, SGI, SHTML, SIX, SIXEL, SPARSE-COLOR, SR2, SRF, STEGANO, SUN, SVG, SVGZ, TEXT, TGA, THUMBNAIL, TIFF, TIFF64, TILE, TIM, TTC, TTF, TXT, UBRL, UBRL6, UIL, UYVY, VDA, VICAR, VID, VIFF, VIPS, VST, WBMP, WEBP, WMV, WPG, X3F, XBM, XC, XCF, XPM, XPS, XV, YCbCr, YCbCrA, YUV